### PR TITLE
Fix for --max-size option suggestion

### DIFF
--- a/docs/content/amazonclouddrive.md
+++ b/docs/content/amazonclouddrive.md
@@ -154,5 +154,5 @@ This means that larger files are likely to fail.
 
 Unfortunatly there is no way for rclone to see that this failure is 
 because of file size, so it will retry the operation, as any other
-failure. To avoid this problem, use `--max-size=50GB` option to limit
+failure. To avoid this problem, use `--max-size 50G` option to limit
 the maximum size of uploaded files.


### PR DESCRIPTION
The current test recommends using "--max-size=50GB" which isn't valid - I updated it to be "--max-size 50G".
